### PR TITLE
Fix to avoid errors in Atom's Deprecation Cop

### DIFF
--- a/keymaps/siteleaf-atom.cson
+++ b/keymaps/siteleaf-atom.cson
@@ -7,5 +7,5 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.workspace':
+'.atom-workspace':
   'ctrl-alt-o': 'siteleaf:preview'


### PR DESCRIPTION
This resolves the following error in Atom:

`
keymaps/siteleaf-atom.cson
Use the `atom-workspace` tag instead of the `workspace` class.
`
